### PR TITLE
fix php8 deprecations

### DIFF
--- a/Classes/PHPExcel/Shared/Drawing.php
+++ b/Classes/PHPExcel/Shared/Drawing.php
@@ -68,7 +68,7 @@ class PHPExcel_Shared_Drawing
 	 * @param 	PHPExcel_Style_Font $pDefaultFont	Default font of the workbook
 	 * @return 	int			Value in cell dimension
 	 */
-	public static function pixelsToCellDimension($pValue = 0, PHPExcel_Style_Font $pDefaultFont) {
+	public static function pixelsToCellDimension($pValue, PHPExcel_Style_Font $pDefaultFont) {
 		// Font name and size
 		$name = $pDefaultFont->getName();
 		$size = $pDefaultFont->getSize();
@@ -96,7 +96,7 @@ class PHPExcel_Shared_Drawing
 	 * @param 	PHPExcel_Style_Font $pDefaultFont	Default font of the workbook
 	 * @return 	int		Value in pixels
 	 */
-	public static function cellDimensionToPixels($pValue = 0, PHPExcel_Style_Font $pDefaultFont) {
+	public static function cellDimensionToPixels($pValue, PHPExcel_Style_Font $pDefaultFont) {
 		// Font name and size
 		$name = $pDefaultFont->getName();
 		$size = $pDefaultFont->getSize();

--- a/Classes/PHPExcel/Worksheet.php
+++ b/Classes/PHPExcel/Worksheet.php
@@ -439,17 +439,17 @@ class PHPExcel_Worksheet implements PHPExcel_IComparable
             throw new PHPExcel_Exception('Sheet code name cannot be empty.');
         }
         // Some of the printable ASCII characters are invalid:  * : / \ ? [ ] and  first and last characters cannot be a "'"
-        if ((str_replace(self::$_invalidCharacters, '', $pValue) !== $pValue) || 
-            (PHPExcel_Shared_String::Substring($pValue,-1,1)=='\'') || 
+        if ((str_replace(self::$_invalidCharacters, '', $pValue) !== $pValue) ||
+            (PHPExcel_Shared_String::Substring($pValue,-1,1)=='\'') ||
             (PHPExcel_Shared_String::Substring($pValue,0,1)=='\'')) {
             throw new PHPExcel_Exception('Invalid character found in sheet code name');
         }
- 
+
         // Maximum 31 characters allowed for sheet title
         if ($CharCount > 31) {
             throw new PHPExcel_Exception('Maximum 31 characters allowed in sheet code name.');
         }
- 
+
         return $pValue;
     }
 
@@ -1216,8 +1216,8 @@ class PHPExcel_Worksheet implements PHPExcel_IComparable
 		$cell = $this->_cellCollection->addCacheData(
 			$pCoordinate,
 			new PHPExcel_Cell(
-				NULL, 
-				PHPExcel_Cell_DataType::TYPE_NULL, 
+				NULL,
+				PHPExcel_Cell_DataType::TYPE_NULL,
 				$this
 			)
 		);
@@ -1244,7 +1244,7 @@ class PHPExcel_Worksheet implements PHPExcel_IComparable
 
         return $cell;
 	}
-	
+
     /**
      * Does the cell at a specific coordinate exist?
      *
@@ -1478,7 +1478,7 @@ class PHPExcel_Worksheet implements PHPExcel_IComparable
      * @param $pValue PHPExcel_Style_Conditional[]
      * @return PHPExcel_Worksheet
      */
-    public function setConditionalStyles($pCoordinate = 'A1', $pValue)
+    public function setConditionalStyles($pCoordinate, $pValue)
     {
         $this->_conditionalStylesCollection[strtoupper($pCoordinate)] = $pValue;
         return $this;
@@ -1496,7 +1496,7 @@ class PHPExcel_Worksheet implements PHPExcel_IComparable
     public function getStyleByColumnAndRow($pColumn = 0, $pRow = 1, $pColumn2 = null, $pRow2 = null)
     {
         if (!is_null($pColumn2) && !is_null($pRow2)) {
-		    $cellRange = PHPExcel_Cell::stringFromColumnIndex($pColumn) . $pRow . ':' . 
+		    $cellRange = PHPExcel_Cell::stringFromColumnIndex($pColumn) . $pRow . ':' .
                 PHPExcel_Cell::stringFromColumnIndex($pColumn2) . $pRow2;
 		    return $this->getStyle($cellRange);
 	    }
@@ -2894,7 +2894,7 @@ class PHPExcel_Worksheet implements PHPExcel_IComparable
 		self::_checkSheetCodeName($pValue);
 
 		// We use the same code that setTitle to find a valid codeName else not using a space (Excel don't like) but a '_'
-		
+
         if ($this->getParent()) {
 			// Is there already such sheet name?
 			if ($this->getParent()->sheetCodeNameExists($pValue)) {

--- a/Classes/PHPExcel/Writer/Excel2007/Chart.php
+++ b/Classes/PHPExcel/Writer/Excel2007/Chart.php
@@ -1339,7 +1339,7 @@ class PHPExcel_Writer_Excel2007_Chart extends
   private function _writePlotSeriesValues($plotSeriesValues,
       $objWriter,
       $groupType,
-      $dataType = 'str',
+      $dataType,
       PHPExcel_Worksheet $pSheet
   ) {
     if (is_null($plotSeriesValues)) {


### PR DESCRIPTION
required params shouldn't come after optional ones, see https://php.watch/versions/8.0/deprecate-required-param-after-optional

forms pr: https://github.com/formstack/web/pull/23179

@kip9 you reviewed similar changes in the past so I'm setting you as reviewer :) 