### PR TITLE
Update ReferenceHelper.php

### DIFF
--- a/Classes/PHPExcel/ReferenceHelper.php
+++ b/Classes/PHPExcel/ReferenceHelper.php
@@ -889,9 +889,9 @@ class PHPExcel_ReferenceHelper
 			list($newColumn, $newRow) = PHPExcel_Cell::coordinateFromString( $pCellReference );
 
 			// Verify which parts should be updated
-			$updateColumn = (($newColumn{0} != '$') && ($beforeColumn{0} != '$') &&
+			$updateColumn = (($newColumn[0] != '$') && ($beforeColumn[0] != '$') &&
 							 PHPExcel_Cell::columnIndexFromString($newColumn) >= PHPExcel_Cell::columnIndexFromString($beforeColumn));
-			$updateRow = (($newRow{0} != '$') && ($beforeRow{0} != '$') &&
+			$updateRow = (($newRow[0] != '$') && ($beforeRow[0] != '$') &&
 						  $newRow >= $beforeRow);
 
 			// Create new column reference


### PR DESCRIPTION
Fixed Fatal error: Array and string offset access syntax with curly braces is no longer supported 